### PR TITLE
Update TrailFluid.pde

### DIFF
--- a/TrailFluid.pde
+++ b/TrailFluid.pde
@@ -71,7 +71,7 @@ PShader blur;
         
            noStroke();
            
-           fill(0,0,0,100);
+           fill(0,0,0,.01);
            rect(0,0,width,height);
 
         


### PR DESCRIPTION
Fade alpha needs to be .01 because it's using colorMode(RGB, 1); in mouseMoved()

Discussion here:
https://forum.processing.org/two/discussion/25762/each-frame-stored-and-fading-out-in-the-draw

(this is a smaller change)